### PR TITLE
各セッションで入力欄に自動フォーカスを実装

### DIFF
--- a/src/app/practice/play/page.tsx
+++ b/src/app/practice/play/page.tsx
@@ -114,6 +114,7 @@ export default function PracticePlay() {
         value={currentAnswer}
         onChange={setCurrentAnswer}
         onSubmit={handleAnswerSubmit}
+        questionId={currentQuestion?.id}
       />
 
       {isGeneratingFeedback && (

--- a/src/features/practice/components/AnswerInput.tsx
+++ b/src/features/practice/components/AnswerInput.tsx
@@ -1,12 +1,28 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
+
 type AnswerInputProps = {
   value: string
   onChange: (value: string) => void
   onSubmit?: (answer: string) => void
+  questionId?: number
 }
 
-export const AnswerInput: React.FC<AnswerInputProps> = ({ value, onChange, onSubmit }) => {
+export const AnswerInput: React.FC<AnswerInputProps> = ({
+  value,
+  onChange,
+  onSubmit,
+  questionId,
+}) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus()
+    }
+  }, [questionId])
+
   const handleSubmit = () => {
     if (value.trim() && onSubmit) {
       onSubmit(value.trim())
@@ -23,6 +39,7 @@ export const AnswerInput: React.FC<AnswerInputProps> = ({ value, onChange, onSub
   return (
     <div>
       <textarea
+        ref={textareaRef}
         rows={4}
         value={value}
         onChange={e => onChange(e.target.value)}


### PR DESCRIPTION
- AnswerInputコンポーネントにquestionIdプロパティを追加
- useEffectの依存配列をquestionIdのみに変更
- 問題切り替え時（スキップ含む）に確実にフォーカスが当たるよう修正